### PR TITLE
设定图片的上传路径

### DIFF
--- a/lib/cos_helper.js
+++ b/lib/cos_helper.js
@@ -93,7 +93,7 @@ function loadLocalFiles(cfgs, publicDir, localFileMap, localImgsMap) {
             let imgRegExp = new RegExp(strRegExp, 'gi');
             //如果是图片目录，将目录内图片文件列表写入 localImgsMap 对象，将上传到单独的 bucket
             if (file.match(cfgs.imageConfig.folder)) {
-                localImgsMap.set(getUploadPath(file).replace(cfgs.imageConfig.folder + '\/', ''), path.join(publicDir, file));
+                localImgsMap.set(cfgs.imageConfig.cloudFolder +getUploadPath(file).replace(cfgs.imageConfig.folder + '\/', ''), path.join(publicDir, file));
             }
             else {
                 if (file.match(/\.html$/)) {
@@ -556,5 +556,6 @@ function checkConfigs(config) {
     cfgs.imageConfig.cdnUrl = cfgs.imageConfig.cdnUrl.replace(/([^\/])$/, '$1\/');
     cfgs.imageConfig.cdnEnable = cfgs.imageConfig.cdnEnable === undefined ? true : cfgs.imageConfig.cdnEnable;
     cfgs.imageConfig.deleteExtraFiles = cfgs.imageConfig.deleteExtraFiles === undefined ? false : cfgs.imageConfig.deleteExtraFiles;
+    cfgs.imageConfig.cloudFolder = cfgs.imageConfig.cdnUrl.split('/').slice(3).join('/');
     return cfgs;
 }


### PR DESCRIPTION

- 基于 cdnUrl 设定图片上传路径，举个栗子：
- 当 `cdnUrl` 设定为： `https://img.inkss.cn/inkss_cn/img/` 时，图片文件将被上传至 `inkss_cn/img/` 目录下